### PR TITLE
removed mock data and related functions

### DIFF
--- a/lib/stores/cv-data-store.ts
+++ b/lib/stores/cv-data-store.ts
@@ -5,8 +5,6 @@ import { persist, createJSONStorage } from "zustand/middleware"
 import { defaultInitState } from "./cv-data-initstate"
 import { createStore } from "zustand/vanilla"
 
-const mockData = process.env.NODE_ENV === "development" ? require("@/mockdata/mock").default : undefined
-
 export const initCvDataStore = (): CvDataState => {
   return { ...defaultInitState }
 }
@@ -23,7 +21,6 @@ export const createCvDataStore = (initState: CvDataState = defaultInitState) => 
         getSectionData: (section) => get()[section],
         setSectionData: (section, data) => set((state) => ({ [section]: { ...state[section], ...data } })),
         reset: () => set(defaultInitState),
-        loadMockData: () => set(() => mockData),
       }),
       {
         name: "cv-data-store",

--- a/lib/stores/cv-data-store.types.ts
+++ b/lib/stores/cv-data-store.types.ts
@@ -42,7 +42,6 @@ export type CvDataActions = {
   getSectionData: <T extends SectionName>(sectionName: T) => CvDataState[T]
   setSectionData: (sectionName: SectionName, data: Omit<CvDataState[SectionName], "email">) => void
   reset: () => void
-  loadMockData: () => void
 }
 
 export type CvDataStore = CvDataState & CvDataActions


### PR DESCRIPTION
Didn't really use it, session storage keeps input values, now they get loaded into the form steps automatically. With the introduction of the persistent save function, this feature will be totally redundant anyway...