### PR TITLE
Fix date pickers: placeholder state, from/to range, future-date guard

### DIFF
--- a/form-generator/field-factory-wrapper.test.tsx
+++ b/form-generator/field-factory-wrapper.test.tsx
@@ -1,0 +1,79 @@
+import type { FieldValues } from "react-hook-form"
+import { render, screen } from "../test-utils"
+import { useForm, FormProvider, Controller } from "react-hook-form"
+import { describe, test, expect } from "bun:test"
+import FieldFactoryWrapper, { isDateDisabled } from "./field-factory-wrapper"
+
+function DateRangeTestForm({ startDate, endDate }: { startDate?: Date; endDate?: Date }) {
+  const form = useForm<FieldValues>({ defaultValues: { startDate, endDate } })
+
+  return (
+    <FormProvider {...form}>
+      <Controller
+        control={form.control}
+        name="startDate"
+        render={({ field }) => (
+          <FieldFactoryWrapper
+            field={field}
+            fieldKey="startDate"
+            fieldProps={{ label: "Start date", type: "date" }}
+            setError={form.setError}
+          />
+        )}
+      />
+      <Controller
+        control={form.control}
+        name="endDate"
+        render={({ field }) => (
+          <FieldFactoryWrapper
+            field={field}
+            fieldKey="endDate"
+            fieldProps={{ label: "End date", type: "date" }}
+            setError={form.setError}
+          />
+        )}
+      />
+    </FormProvider>
+  )
+}
+
+describe("FieldFactoryWrapper date picker", () => {
+  test("shows a placeholder instead of a preselected date when no date is chosen", () => {
+    render(<DateRangeTestForm />)
+
+    expect(screen.getAllByText("Pick a date")).toHaveLength(2)
+  })
+})
+
+describe("isDateDisabled", () => {
+  const today = new Date("2024-06-15")
+
+  test("disables dates after today", () => {
+    expect(isDateDisabled(new Date("2024-06-16"), "startDate", undefined, today)).toBe(true)
+  })
+
+  test("allows today and earlier dates when there is no paired date", () => {
+    expect(isDateDisabled(today, "startDate", undefined, today)).toBe(false)
+    expect(isDateDisabled(new Date("2024-06-14"), "startDate", undefined, today)).toBe(false)
+  })
+
+  test("disables dates before the 1900 lower bound", () => {
+    expect(isDateDisabled(new Date("1899-12-31"), "startDate", undefined, today)).toBe(true)
+  })
+
+  test("start-date picker disables dates after the paired end date", () => {
+    const pairedEndDate = new Date("2024-06-10")
+
+    expect(isDateDisabled(new Date("2024-06-11"), "startDate", pairedEndDate, today)).toBe(true)
+    expect(isDateDisabled(new Date("2024-06-10"), "startDate", pairedEndDate, today)).toBe(false)
+    expect(isDateDisabled(new Date("2024-06-01"), "startDate", pairedEndDate, today)).toBe(false)
+  })
+
+  test("end-date picker disables dates before the paired start date", () => {
+    const pairedStartDate = new Date("2024-06-10")
+
+    expect(isDateDisabled(new Date("2024-06-09"), "endDate", pairedStartDate, today)).toBe(true)
+    expect(isDateDisabled(new Date("2024-06-10"), "endDate", pairedStartDate, today)).toBe(false)
+    expect(isDateDisabled(new Date("2024-06-11"), "endDate", pairedStartDate, today)).toBe(false)
+  })
+})

--- a/form-generator/field-factory-wrapper.tsx
+++ b/form-generator/field-factory-wrapper.tsx
@@ -13,8 +13,28 @@ import { format } from "date-fns"
 import { enUS, hu } from "date-fns/locale"
 import { useLocale, useTranslations } from "next-intl"
 import { useState } from "react"
+import { useFormContext, useWatch } from "react-hook-form"
 
 const dateLocales = { en: enUS, hu } as const
+
+// Work experience / education sections use this from-to date pair naming convention
+const datePairKeys: Record<string, string> = {
+  startDate: "endDate",
+  endDate: "startDate",
+}
+
+const MIN_PICKABLE_DATE = new Date("1900-01-01")
+
+export function isDateDisabled(
+  date: Date,
+  fieldKey: string,
+  pairedDate: Date | undefined,
+  now: Date = new Date()
+): boolean {
+  if (date > now || date < MIN_PICKABLE_DATE) return true
+  if (!pairedDate) return false
+  return fieldKey === "startDate" ? date > pairedDate : date < pairedDate
+}
 
 export interface FieldFactoryWrapperProps {
   field: ControllerRenderProps
@@ -33,6 +53,10 @@ export default function FieldFactoryWrapper({
   const [isCalendarOpen, setIsCalendarOpen] = useState<{ [fieldKey: string]: boolean }>({})
   const t = useTranslations("CreateFlow.actions")
   const locale = useLocale() as keyof typeof dateLocales
+  const { control } = useFormContext()
+  const pairedFieldKey = datePairKeys[fieldKey]
+  const pairedDateValue = useWatch({ control, name: pairedFieldKey ?? fieldKey })
+  const pairedDate: Date | undefined = pairedFieldKey ? pairedDateValue : undefined
 
   const fieldFactory = () => {
     switch (type) {
@@ -90,9 +114,9 @@ export default function FieldFactoryWrapper({
                 captionLayout="dropdown-buttons"
                 selected={field.value}
                 onSelect={field.onChange}
-                fromDate={new Date("1900-01-01")}
+                fromDate={MIN_PICKABLE_DATE}
                 toDate={new Date()}
-                disabled={(date) => date > new Date() || date < new Date("1900-01-01")}
+                disabled={(date) => isDateDisabled(date, fieldKey, pairedDate)}
                 onDayClick={() =>
                   setIsCalendarOpen((prev) => ({ ...prev, [fieldKey]: !(prev[fieldKey] || false) }))
                 }

--- a/form-generator/validation-schemas.test.ts
+++ b/form-generator/validation-schemas.test.ts
@@ -1,0 +1,61 @@
+import { describe, test, expect } from "bun:test"
+import { getSectionSchemas } from "./validation-schemas"
+
+const t = (key: string) => key
+
+describe("date range validation (experience & education)", () => {
+  const { experience, education } = getSectionSchemas(t)
+
+  const validEntry = {
+    jobTitle: "Engineer",
+    employer: "Acme",
+    description: "Built things",
+    startDate: new Date("2020-01-01"),
+    endDate: new Date("2021-01-01"),
+    location: "Remote",
+  }
+
+  test("accepts a start date before the end date", () => {
+    const result = experience.safeParse(validEntry)
+    expect(result.success).toBe(true)
+  })
+
+  test("accepts a start date equal to the end date", () => {
+    const result = experience.safeParse({ ...validEntry, endDate: validEntry.startDate })
+    expect(result.success).toBe(true)
+  })
+
+  test("rejects a start date after the end date, flagging endDate", () => {
+    const result = experience.safeParse({
+      ...validEntry,
+      startDate: new Date("2021-01-01"),
+      endDate: new Date("2020-01-01"),
+    })
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const issue = result.error.issues.find((i) => i.message === "validation.common.dateRangeInvalid")
+      expect(issue?.path).toEqual(["endDate"])
+    }
+  })
+
+  test("applies the same rule to the education schema", () => {
+    const validEducationEntry = {
+      institution: "State University",
+      major: "CS",
+      specialization: "AI",
+      description: "",
+      startDate: new Date("2021-01-01"),
+      endDate: new Date("2020-01-01"),
+      location: "Remote",
+    }
+
+    const result = education.safeParse(validEducationEntry)
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const issue = result.error.issues.find((i) => i.message === "validation.common.dateRangeInvalid")
+      expect(issue?.path).toEqual(["endDate"])
+    }
+  })
+})

--- a/form-generator/validation-schemas.ts
+++ b/form-generator/validation-schemas.ts
@@ -39,6 +39,16 @@ function getOptionalUrlSchema(t: Translate) {
     )
 }
 
+function withDateRangeValidation<T extends z.ZodObject<{ startDate: z.ZodTypeAny; endDate: z.ZodTypeAny }>>(
+  schema: T,
+  t: Translate
+) {
+  return schema.refine((data) => !data.startDate || !data.endDate || data.startDate <= data.endDate, {
+    message: t("validation.common.dateRangeInvalid"),
+    path: ["endDate"],
+  })
+}
+
 export function getSectionSchemas(t: Translate) {
   const optionalUrlSchema = getOptionalUrlSchema(t)
 
@@ -80,26 +90,32 @@ export function getSectionSchemas(t: Translate) {
         .min(1, { message: t("validation.skills.skillsListRequired") })
         .min(3, { message: t("validation.common.tooShort") }),
     }),
-    experience: z.object({
-      jobTitle: z.string().min(1, { message: t("validation.experience.jobTitleRequired") }),
-      employer: z.string().min(1, { message: t("validation.experience.employerRequired") }),
-      description: z
-        .string()
-        .min(1, { message: t("validation.experience.descriptionRequired") })
-        .min(3, { message: t("validation.common.tooShort") }),
-      startDate: z.date({ message: t("validation.common.dateRequired") }),
-      endDate: z.date({ message: t("validation.common.dateRequired") }),
-      location: z.string().min(1, { message: t("validation.experience.locationRequired") }),
-    }),
-    education: z.object({
-      institution: z.string().min(1, { message: t("validation.education.institutionRequired") }),
-      major: z.string(),
-      specialization: z.string().min(1, { message: t("validation.education.specializationRequired") }),
-      description: z.string(),
-      startDate: z.date({ message: t("validation.common.dateRequired") }),
-      endDate: z.date({ message: t("validation.common.dateRequired") }),
-      location: z.string().min(1, { message: t("validation.education.locationRequired") }),
-    }),
+    experience: withDateRangeValidation(
+      z.object({
+        jobTitle: z.string().min(1, { message: t("validation.experience.jobTitleRequired") }),
+        employer: z.string().min(1, { message: t("validation.experience.employerRequired") }),
+        description: z
+          .string()
+          .min(1, { message: t("validation.experience.descriptionRequired") })
+          .min(3, { message: t("validation.common.tooShort") }),
+        startDate: z.date({ message: t("validation.common.dateRequired") }),
+        endDate: z.date({ message: t("validation.common.dateRequired") }),
+        location: z.string().min(1, { message: t("validation.experience.locationRequired") }),
+      }),
+      t
+    ),
+    education: withDateRangeValidation(
+      z.object({
+        institution: z.string().min(1, { message: t("validation.education.institutionRequired") }),
+        major: z.string(),
+        specialization: z.string().min(1, { message: t("validation.education.specializationRequired") }),
+        description: z.string(),
+        startDate: z.date({ message: t("validation.common.dateRequired") }),
+        endDate: z.date({ message: t("validation.common.dateRequired") }),
+        location: z.string().min(1, { message: t("validation.education.locationRequired") }),
+      }),
+      t
+    ),
     languages: z.object({
       language: z.string().min(1, { message: t("validation.languages.languageRequired") }),
       level: z.string().min(1, { message: t("validation.languages.levelRequired") }),
@@ -107,7 +123,7 @@ export function getSectionSchemas(t: Translate) {
     interests: z.object({
       interestsList: z.string().optional(),
     }),
-  } satisfies Record<SectionName, z.ZodObject<any>>
+  } satisfies Record<SectionName, z.ZodType<any>>
 }
 
 type SectionSchemas = ReturnType<typeof getSectionSchemas>

--- a/lib/stores/cv-data-initstate.test.ts
+++ b/lib/stores/cv-data-initstate.test.ts
@@ -1,0 +1,24 @@
+import { describe, test, expect } from "bun:test"
+import { defaultInitState } from "./cv-data-initstate"
+
+// A date picker whose form field defaults to `new Date()` renders as if the user
+// already chose today's date. These fields must start unset so pickers show a placeholder.
+describe("defaultInitState", () => {
+  test("birthDate starts unset", () => {
+    expect(defaultInitState.personal.birthDate).toBeUndefined()
+  })
+
+  test("experience startDate/endDate start unset", () => {
+    for (const entry of defaultInitState.experience) {
+      expect(entry.startDate).toBeUndefined()
+      expect(entry.endDate).toBeUndefined()
+    }
+  })
+
+  test("education startDate/endDate start unset", () => {
+    for (const entry of defaultInitState.education) {
+      expect(entry.startDate).toBeUndefined()
+      expect(entry.endDate).toBeUndefined()
+    }
+  })
+})

--- a/lib/stores/cv-data-initstate.ts
+++ b/lib/stores/cv-data-initstate.ts
@@ -9,11 +9,14 @@ import type {
   Interests,
 } from "./cv-data-store.types"
 
+// Dates start unset (not today's date) so pickers show a placeholder until the user actually picks one
+const UNSET_DATE = undefined as unknown as Date
+
 const personalSection: Personal = {
   firstName: "",
   middleName: "",
   lastName: "",
-  birthDate: new Date(),
+  birthDate: UNSET_DATE,
   phone: "",
   email: "",
   location: "",
@@ -37,8 +40,8 @@ const experienceSection: Employment[] = [
     employer: "",
     jobTitle: "",
     description: "",
-    startDate: new Date(),
-    endDate: new Date(),
+    startDate: UNSET_DATE,
+    endDate: UNSET_DATE,
     location: "",
   },
 ]
@@ -49,8 +52,8 @@ const educationSection: School[] = [
     major: "",
     specialization: "",
     description: "",
-    startDate: new Date(),
-    endDate: new Date(),
+    startDate: UNSET_DATE,
+    endDate: UNSET_DATE,
     location: "",
   },
 ]

--- a/messages/en.json
+++ b/messages/en.json
@@ -188,7 +188,8 @@
     "validation": {
       "common": {
         "tooShort": "This is unfortunately too short",
-        "dateRequired": "Date is required"
+        "dateRequired": "Date is required",
+        "dateRangeInvalid": "Start date must be before end date"
       },
       "email": {
         "required": "Email address is required",

--- a/messages/hu.json
+++ b/messages/hu.json
@@ -188,7 +188,8 @@
     "validation": {
       "common": {
         "tooShort": "Ez sajnos túl rövid",
-        "dateRequired": "Dátum kitöltése kötelező"
+        "dateRequired": "Dátum kitöltése kötelező",
+        "dateRangeInvalid": "A kezdő dátumnak korábbinak kell lennie, mint a záró dátum"
       },
       "email": {
         "required": "Email cím kitöltése kötelező",


### PR DESCRIPTION
## Summary
- Date pickers (birth date, work experience, education) defaulted to `new Date()`, so they looked pre-selected on today's date even though the form state was never touched. They now start unset and show the "Pick a date" placeholder.
- Work experience and education "from"/"to" date pairs now disable invalid choices on the calendar (start can't be after end, end can't be before start) and enforce the same rule at submit time via a zod cross-field refinement.
- Future dates were already disabled on the calendar; verified this still works after the above changes.

Closes #14

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun test` (added tests for unset default dates, date-range zod validation, and the `isDateDisabled` calendar predicate)
- [x] Manual check in browser: add a work experience entry, confirm placeholder shows, pick a start date, confirm end-date calendar disables days before it (and vice versa)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ppvonM5e6psp9uV6wbuWd